### PR TITLE
Cdi lab update

### DIFF
--- a/kubevirt-cdi/index.json
+++ b/kubevirt-cdi/index.json
@@ -27,6 +27,6 @@
     "uilayout": "terminal"
   },
   "backend": {
-    "imageid": "kubernetes"
+    "imageid": "kubernetes-cluster-running:1.18"
   }
 }

--- a/kubevirt-cdi/step1.md
+++ b/kubevirt-cdi/step1.md
@@ -24,11 +24,16 @@ Now let's deploy KubeVirt by creating a Custom Resource that will trigger the 'o
 `kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml`{{execute}}
 
 Let's check the deployment:
+
+`kubectl get kubevirt -n kubevirt`{{execute}}
+
+It will take a while until all the pods are running. Retry the command until the output states that kubevirt is "Deployed".
+
+Once the kubevirt resource is deployed, view the pods created by the deployment. 
+
 `kubectl get pods -n kubevirt`{{execute}}
 
-This will take a while until all the pods are running, retry the command until the output states that all fo them are running.
-
-Once it's ready, it will show something similar to:
+It will show something similar to:
 
 ~~~
 master $ kubectl get pods -n kubevirt

--- a/kubevirt-upgrades/index.json
+++ b/kubevirt-upgrades/index.json
@@ -29,6 +29,6 @@
     "icon": "fa-kubernetes"
   },
   "backend": {
-    "imageid": "kubernetes"
+    "imageid": "kubernetes-cluster-running:1.18"
   }
 }


### PR DESCRIPTION
  - Updates lab to recent Katacoda kubernetes image for 1.18
  - Eliminates dependency on kubevirt.io website lab artifacts (except for vm definition)
  - Installs kubevirt-hostpath-provisioner
  - Installs PVC definition as here document
  - Updates Fedora image to latest 34
  - Does not destroy the katacoda ssh key