### PR TITLE
New KataCoda Scenario - Migration Lab

### DIFF
--- a/kubevirt-migration/environment.sh
+++ b/kubevirt-migration/environment.sh
@@ -1,0 +1,32 @@
+launch.sh
+
+# Need schedulable for migration
+kubectl taint node controlplane node-role.kubernetes.io/master:NoSchedule-
+
+export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases/latest | jq -r .tag_name)
+echo Installing Kubevirt $KUBEVIRT_VERSION
+
+kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
+
+kubectl create configmap kubevirt-config -n kubevirt \
+    --from-literal debug.useEmulation=true \
+    --from-literal feature-gates=LiveMigration
+
+kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
+
+wget -O virtctl https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-amd64
+
+sudo install -m 0755  virtctl /usr/local/bin/virtctl
+rm -f virtctl
+
+tries=10
+output=$(kubectl -n kubevirt get kubevirt kubevirt -o jsonpath='{.status.phase}')
+while [ $tries -gt 0 ] && [ "$output" != "Deployed" ]
+do
+    echo KubeVirt in ${output:-Uninitialized} phase.
+    sleep $(( tries * 3 ))
+    let tries--
+    output=$(kubectl -n kubevirt get kubevirt kubevirt -o jsonpath='{.status.phase}')
+done
+
+kubectl -n kubevirt get kubevirt kubevirt

--- a/kubevirt-migration/index.json
+++ b/kubevirt-migration/index.json
@@ -1,0 +1,32 @@
+{
+  "pathwayTitle": "KubeVirt",
+  "title": "Live Migration in KubeVirt",
+  "description": "Live migration is a virtualization feature supported by KubeVirt that allows moving VMs between nodes, preserving running services. Deploy it and play with it in a hosted sandboxed interactive environment.",
+  "time": "15min",
+  "difficulty": "beginner",
+  "details": {
+    "intro": {
+      "text": "intro.md",
+      "code": "environment.sh"
+    },
+    "steps": [
+      {
+        "title": "Create a VM and set up a service.",
+        "text": "step1.md"
+      },
+      {
+        "title": "Migrate the VM and follow the service.",
+        "text": "step2.md"
+      }
+    ],
+    "finish": {
+      "text": "summary.md"
+    }
+  },
+  "environment": {
+    "uilayout": "terminal"
+  },
+  "backend": {
+    "imageid": "kubernetes-cluster-running:1.18"
+  }
+}

--- a/kubevirt-migration/intro.md
+++ b/kubevirt-migration/intro.md
@@ -1,0 +1,7 @@
+Live Migration is a common virtualization feature supported by KubeVirt where
+virtual machines running on one cluster node move to another cluster node
+without shutting down the guest OS or its applications.
+
+This scenario demonstrates how to migrate a VM from one node to another in a KubeVirt cluster.
+
+For more information, see the [KubeVirt Project's Live Migration Lab](https://kubevirt.io/labs/kubernetes/migration.html)

--- a/kubevirt-migration/step1.md
+++ b/kubevirt-migration/step1.md
@@ -31,7 +31,7 @@ The testvm virtual machine should start running on node01. Check which node the 
 
 `kubectl get vmi`{{execute}}
 
-You should see something like:
+Once the VM reaches the Running phase, you should see something like:
 
 ~~~sh
 NAME     AGE   PHASE     IP           NODENAME
@@ -40,7 +40,7 @@ testvm   17s   Running   10.244.1.7   node01
 
 For more detailed information, you can use directly view the virt-launcher Pod(s) with:
 
-`kubectl get po -o wide`{{execute}}
+`kubectl get pods -o wide`{{execute}}
 
 ~~~sh
 NAME                         READY   STATUS    RESTARTS   AGE   IP           NODE     NOMINATED NODE   READINESS GATES

--- a/kubevirt-migration/step1.md
+++ b/kubevirt-migration/step1.md
@@ -1,0 +1,50 @@
+### Wait for KubeVirt to deploy
+
+The setup for this scenario includes installation of KubeVirt and the `virtctl` utility.
+
+Before we can start, we need to wait for the Kubernetes cluster and KubeVirt
+initialization script to run. (a command prompt will appear once everything is
+ready).
+
+#### Check the kubevirt-config
+
+When KubeVirt finishes deploying, list out the ConfigMap "kubevirt-config" in
+the "kubevirt" namespace.
+
+In addition to emulated virtualization (a requirement in this environment), a
+feature gate has also been added to make live migration possible.
+
+`kubectl -n kubevirt get configmap kubevirt-config -o yaml`{{execute}}
+
+### Launch the test VM
+
+This scenario will use the same VirtualMachine YAML definition from the first
+lab. Run the following code to create the VM.
+
+`kubectl apply -f https://raw.githubusercontent.com/kubevirt/demo/master/manifests/vm.yaml`{{execute}}
+
+Run the following to start the VM.
+
+`virtctl start testvm`{{execute}}
+
+The testvm virtual machine should start running on node01. Check which node the VM is on with:
+
+`kubectl get vmi`{{execute}}
+
+You should see something like:
+
+~~~sh
+NAME     AGE   PHASE     IP           NODENAME
+testvm   17s   Running   10.244.1.7   node01
+~~~
+
+For more detailed information, you can use directly view the virt-launcher Pod(s) with:
+
+`kubectl get po -o wide`{{execute}}
+
+~~~sh
+NAME                         READY   STATUS    RESTARTS   AGE   IP           NODE     NOMINATED NODE   READINESS GATES
+virt-launcher-testvm-676tr   2/2     Running   0          80s   10.244.1.7   node01   <none>           <none>
+~~~
+
+Make note of the VM's node, and move ahead to the next step.

--- a/kubevirt-migration/step2.md
+++ b/kubevirt-migration/step2.md
@@ -1,0 +1,140 @@
+#### Deploy a service on the VM
+
+Create two NodePort services to access ports on the VM:
+
+`
+virtctl expose vmi testvm --name=testvm-ssh --port=22 --type=NodePort
+virtctl expose vmi testvm --name=testvm-http --port=8080 --type=NodePort
+`{{execute}}
+
+Save the SSH NodePort to a variable:
+
+`SSHPORT=$(kubectl get service testvm-ssh -o jsonpath='{.spec.ports[0].nodePort}')`{{execute}}
+
+The Cirros VM uses a default username and password of `cirros:gocubsgo`. Using
+sshpass, we can automatically run commands on the testvm without a password
+prompt. First, hide the password in an environment variable:
+
+`export SSHPASS=gocubsgo`{{execute}}
+
+Next, ssh into testvm and run the hostname command:
+
+`sshpass -e ssh node01 -l cirros -p $SSHPORT hostname`{{execute}}
+
+If all went well, this should print the VM's hostname, "testvm".
+
+Next, we will try something more complicated. Due to cirros' lack of a
+webserver, we will create one using a while loop and the netcat utility (which
+cirros does include).
+
+The bash loop looks like:
+
+~~~sh
+while true
+do
+    ( echo "HTTP/1.0 200 Ok"; echo; echo "Migration test" ) | nc -l -p 8080
+done
+~~~
+
+The full command looks like the following, with `-f` added to background the
+ssh session and return control to the controlplane node.
+
+`sshpass -e ssh node01 -l cirros -p $SSHPORT -f 'while true; do ( echo "HTTP/1.0 200 Ok"; echo; echo "Migration test" ) | nc -l -p 8080; done'`{{execute}}
+
+As with the ssh NodePort, it will be necessary to capture the http NodePort to a variable.
+
+`HTTPPORT=$(kubectl get service testvm-http -o jsonpath='{.spec.ports[0].nodePort}')`{{execute}}
+
+Test the http connection:
+
+`curl node01:$HTTPPORT`{{execute}}
+
+This should return something like the following:
+
+~~~sh
+GET / HTTP/1.1
+Host: node01:30115
+User-Agent: curl/7.58.0
+Accept: */*
+
+Migration test
+~~~
+
+Note that the first part is actually netcat echoing curl instructions over your
+backgrounded ssh connection. The important part is "Migration test" at the
+bottom.
+
+#### Migrate the VM
+
+Migration is a straightforward procedure with virtctl. To start a migration, run:
+
+`virtctl migrate testvm`{{execute}}
+
+This should return:
+
+~~~
+VM testvm was scheduled to migrate
+~~~
+
+Run the following multiple times to follow the migration:
+
+`kubectl get vmi,po -o wide`{{execute}}
+
+KubeVirt will schedule and start a virt-launcher pod instance on the target node, "controlplane" in our case:
+
+~~~
+NAME                                        AGE   PHASE     IP           NODENAME   LIVE-MIGRATABLE   PAUSED
+virtualmachineinstance.kubevirt.io/testvm   26m   Running   10.244.1.7   node01     True
+
+NAME                             READY   STATUS    RESTARTS   AGE   IP           NODE           NOMINATED NODE   READINESS GATES
+pod/virt-launcher-testvm-676tr   2/2     Running   0          26m   10.244.1.7   node01         <none>           <none>
+pod/virt-launcher-testvm-fd2lj   2/2     Running   0          21s   10.244.0.9   controlplane   <none>           <none>
+~~~
+
+Once the two virt-launcher pods are synchronized, control will swap over to the new one, and the other will be scheduled for shutdown.
+
+~~~
+NAME                                        AGE   PHASE     IP           NODENAME       LIVE-MIGRATABLE   PAUSED
+virtualmachineinstance.kubevirt.io/testvm   27m   Running   10.244.0.9   controlplane   True              
+
+NAME                             READY   STATUS     RESTARTS   AGE   IP           NODE           NOMINATED NODE   READINESS GATES
+pod/virt-launcher-testvm-676tr   1/2     NotReady   0          27m   10.244.1.7   node01         <none>           <none>
+pod/virt-launcher-testvm-fd2lj   2/2     Running    0          54s   10.244.0.9   controlplane   <none>           <none>
+~~~
+
+Eventually, the old virt-launcher will enter a Completed state:
+
+~~~
+NAME                                        AGE   PHASE     IP           NODENAME       LIVE-MIGRATABLE   PAUSED
+virtualmachineinstance.kubevirt.io/testvm   27m   Running   10.244.0.9   controlplane   True
+
+NAME                             READY   STATUS      RESTARTS   AGE   IP           NODE           NOMINATED NODE   READINESS GATES
+pod/virt-launcher-testvm-676tr   0/2     Completed   0          27m   10.244.1.7   node01         <none>           <none>
+pod/virt-launcher-testvm-fd2lj   2/2     Running     0          70s   10.244.0.9   controlplane   <none>           <none>
+~~~
+
+#### Test running services on the migrated VM
+
+Run the curl command again. Because NodePorts are forwarded regardless of which node the actual Pod is running on, it is okay to use the same hostname as before even though the VM is now running on controlplane.
+
+`curl node01:$HTTPPORT`{{execute}}
+
+Note that the netcat output of the HTTP headers sent by curl will no longer display, only the output:
+
+~~~
+Migration test
+~~~
+
+This is because the ssh connection that was running the while loop got
+disconnected during the migration. A look at the VM IP will show why this
+happens. In our example, it has changed from 10.244.1.7 to 10.244.0.9.
+
+#### Shutdown and cleanup
+
+Shutting down a VM works by either using `virtctl` or editing the VM.
+
+`virtctl stop testvm`{{execute}}
+
+Finally, the VM can be deleted using:
+
+`kubectl delete vm testvm`{{execute}}

--- a/kubevirt-migration/step2.md
+++ b/kubevirt-migration/step2.md
@@ -78,7 +78,7 @@ VM testvm was scheduled to migrate
 
 Run the following multiple times to follow the migration:
 
-`kubectl get vmi,po -o wide`{{execute}}
+`kubectl get vmis,pods -o wide`{{execute}}
 
 KubeVirt will schedule and start a virt-launcher pod instance on the target node, "controlplane" in our case:
 

--- a/kubevirt-migration/summary.md
+++ b/kubevirt-migration/summary.md
@@ -1,0 +1,3 @@
+Well done, you have completed the KubeVirt demo!
+
+We hope you enjoyed it, for more information about KubeVirt, please do check <https://kubevirt.io>!


### PR DESCRIPTION
Following the framework of our [KubeVirt Migration Lab](https://kubevirt.io/labs/kubernetes/migration.html) I have created a Katacoda scenario that uses the two nodes of a Katacoda 1.18 k8s cluster to perform a live migration of a Cirros VM while running a netcat-in-a-while-loop web "server".

Reviewers may try before merge at: [My Katacoda Profile](https://www.katacoda.com/cwilkers/scenarios/kubevirt-migration)