### PR TITLE
Pin 101 scenario to 0.49.0

### DIFF
--- a/kubevirt-101/step1.md
+++ b/kubevirt-101/step1.md
@@ -6,12 +6,17 @@ Before we can start, we need to wait for the Kubernetes cluster to be ready (a c
 
 Deploy the KubeVirt operator[^1] using the latest KubeVirt version.
 
-[^1] An Operator is a method of packaging, deploying and managing a Kubernetes application. A Kubernetes application is an application that is both deployed on Kubernetes and managed using the Kubernetes APIs and kubectl tooling. You can think of Operators as the runtime that manages this type of application on Kubernetes. If you want to learn more about Operators you can check the CoreOS Operators website: <https://coreos.com/operators/>
+[^1] An Operator is a method of packaging, deploying, and managing a Kubernetes application. A Kubernetes application is one that is deployed on Kubernetes and managed using the Kubernetes APIs and kubectl tooling. You can think of Operators as the runtime that manages this type of application on Kubernetes. If you want to learn more about Operators you can check the [Kubernetes documentation](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
 
-We query GitHub's API to get the latest available release (click on the text to autoexecute the commands on the console):
+Normally, we would query GitHub's API to get the latest available release:
 
 `export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases/latest | jq -r .tag_name)
-echo $KUBEVIRT_VERSION`{{execute}}
+echo $KUBEVIRT_VERSION`
+
+Note: Due to Katacoda supporting an older version of Kubernetes (1.18) than required for recent KubeVirt versions, we will instead set the KUBEVIRT_VERSION environment variable to 0.49.0.
+(click on the text to automatically execute the commands on the console):
+
+`export KUBEVIRT_VERSION=v0.49.0`{{execute}}
 
 Run the following command to deploy the KubeVirt Operator:
 

--- a/kubevirt-gitops/environment.sh
+++ b/kubevirt-gitops/environment.sh
@@ -1,0 +1,25 @@
+launch.sh
+
+# May need both nodes
+kubectl taint node controlplane node-role.kubernetes.io/master:NoSchedule-
+
+# Install Argo-CD
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/core-install.yaml
+
+
+# Install command line tools
+## ArgoCD argocd
+export ARGOCD_VERSION=$(curl -s https://api.github.com/repos/argoproj/argo-cd/releases/latest | jq -r .tag_name)
+wget -O argocd https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64
+sudo install -m 0755 argocd /usr/local/bin/argocd
+rm -f argocd
+
+## Kubevirt virtctl
+export KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases/latest | jq -r .tag_name)
+wget -O virtctl https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-amd64
+
+sudo install -m 0755  virtctl /usr/local/bin/virtctl
+rm -f virtctl
+
+argocd login --core

--- a/kubevirt-gitops/environment.sh
+++ b/kubevirt-gitops/environment.sh
@@ -22,4 +22,10 @@ wget -O virtctl https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIR
 sudo install -m 0755  virtctl /usr/local/bin/virtctl
 rm -f virtctl
 
-argocd login --core
+# Patch argo server to present nodeport to API
+kubectl patch svc argocd-server -n argocd -p '{"spec": {"type": "NodePort"}}'
+
+ARGO_PASS=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d; echo)
+ARGO_PORT=$(kubectl -n argocd get svc argocd-server -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
+
+argocd login localhost:${ARGO_PORT} --username admin --password ${ARGO_PASS}

--- a/kubevirt-gitops/index.json
+++ b/kubevirt-gitops/index.json
@@ -1,0 +1,32 @@
+{
+  "pathwayTitle": "KubeVirt",
+  "title": "GitOps and KubeVirt",
+  "description": "The practice of GitOps combined with KubeVirt enables Virtual Infrastructure as Code. Deploy and experiment with ArgoCD and KubeVirt in a hosted sandboxed interactive environment.",
+  "time": "20min",
+  "difficulty": "intermediate",
+  "details": {
+    "intro": {
+      "text": "intro.md",
+      "code": "environment.sh"
+    },
+    "steps": [
+      {
+        "title": "Explore ArgoCD and use it to install KubeVirt components.",
+        "text": "step1.md"
+      },
+      {
+        "title": "Install and run a VM from a datavolume using gitops",
+        "text": "step2.md"
+      }
+    ],
+    "finish": {
+      "text": "summary.md"
+    }
+  },
+  "environment": {
+    "uilayout": "terminal"
+  },
+  "backend": {
+    "imageid": "kubernetes-cluster-running:1.18"
+  }
+}

--- a/kubevirt-gitops/intro.md
+++ b/kubevirt-gitops/intro.md
@@ -1,0 +1,10 @@
+GitOps is simply defined as managing operations using a version control workflow.
+It consists of three main practices:
+
+- Infrastructure-as-code
+- Change control through pull (or merge) requests
+- Continuous integration / continuous delivery (CI/CD)
+
+With [KubeVirt](https://kubevirt.io), it is possible to increase the scope of Infrastructure as Code to include *Virtual* Infrastructure as Code.
+
+This lab will set up a two node Kubernetes cluster with the CI/CD tool, [ArgoCD](https://argo-cd.readthedocs.io) installed, then demonstrate the process of adding KubeVirt, Hostpath Provisioner, and Containerized Data Importer (CDI). The demonstration will culminate in creation of a VM using ArgoCD.

--- a/kubevirt-gitops/step1.md
+++ b/kubevirt-gitops/step1.md
@@ -1,0 +1,23 @@
+### Use ArgoCD to deploy KubeVirt
+
+First, create the kubevirt application within ArgoCD by pointing to the repository, path, namespace, and local server URI:
+
+`argocd app create kubevirt --repo https://github.com/cwilkers/kubevirt-gitops.git --path kubevirt --dest-namespace kubevirt --dest-server https://kubernetes.default.svc`{{execute create-kubevirt}}
+
+`argocd app sync kubevirt`{{execute sync-kubevirt}}
+
+`argocd app list`{{execute app-list}}
+
+### Use ArgoCD to deploy kubevirt hostpath provisioner and CDI
+
+Create a hostpath-provisioner using the following commands:
+
+`argocd app create hostpath --repo https://github.com/cwilkers/kubevirt-gitops.git --path hostpath --dest-namespace kubevirt-hostpath-provisioner --dest-server https://kubernetes.default.svc`{{execute create-hostpath}}
+
+`argocd app sync hostpath`{{execute sync-hostpath}}
+
+Create and sync the CDI application:
+
+`argocd app create cdi --repo https://github.com/cwilkers/kubevirt-gitops.git --path cdi --dest-namespace cdi --dest-server https://kubernetes.default.svc`{{execute}}
+
+`argocd app sync cdi`{{execute sync-cdi}}

--- a/kubevirt-gitops/step1.md
+++ b/kubevirt-gitops/step1.md
@@ -12,7 +12,7 @@ First, create the kubevirt application within ArgoCD by pointing to the reposito
 
 Create a hostpath-provisioner using the following commands:
 
-`argocd app create hostpath --repo https://github.com/cwilkers/kubevirt-gitops.git --path hostpath --dest-namespace kubevirt-hostpath-provisioner --dest-server https://kubernetes.default.svc`{{execute create-hostpath}}
+`argocd app create hostpath --repo https://github.com/cwilkers/kubevirt-gitops.git --path hpp --dest-namespace kubevirt-hostpath-provisioner --dest-server https://kubernetes.default.svc`{{execute create-hostpath}}
 
 `argocd app sync hostpath`{{execute sync-hostpath}}
 

--- a/kubevirt-gitops/step2.md
+++ b/kubevirt-gitops/step2.md
@@ -1,0 +1,7 @@
+### Create a DataVolume
+
+Placeholder
+
+### Create a VM
+
+Placeholder

--- a/kubevirt-gitops/summary.md
+++ b/kubevirt-gitops/summary.md
@@ -1,0 +1,7 @@
+Well done, you have completed the KubeVirt GitOps demo!
+
+We hope you enjoyed it!
+
+For more information about KubeVirt, please do check out <https://kubevirt.io>
+
+For more information about ArgoCD, please visit <https://argo-cd.readthedocs.io>


### PR DESCRIPTION
Pins kubevirt-101 scenario version to 0.49.0 as Katacoda's k8s version is 1.18, and latest kubevirt is observed to not work.

Also fixes #25 by linking to better k8s documentation for describing operators