### PR TITLE
Remove empty execute marker

### DIFF
--- a/kubevirt-cdi/step2.md
+++ b/kubevirt-cdi/step2.md
@@ -137,7 +137,7 @@ kubectl get vmi
 
 ```
 No resources found in default namespace.
-```{{}}
+```
 
 Start the VM back up
 


### PR DESCRIPTION
Empty {{}} is not needed and may break renderers.