### PR TITLE
Remove usage of deprecated .spec.running field

### DIFF
--- a/kubevirt-101/step2.md
+++ b/kubevirt-101/step2.md
@@ -15,7 +15,7 @@ kubectl get vms
 ```{{execute}}
 
 ```
-kubectl get vms -o yaml testvm | grep -E 'running:.*|$'
+kubectl get vms -o yaml testvm | grep -E 'runStrategy:.*|$'
 ```{{execute}}
 
 Notice from the output that the VM is not running yet.

--- a/kubevirt-cdi/step2.md
+++ b/kubevirt-cdi/step2.md
@@ -46,7 +46,7 @@ metadata:
     kubevirt.io/os: linux
   name: vm1
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null


### PR DESCRIPTION
**What this PR does / why we need it**:
The .spec.running field is deprecated, therefore we should runStrategy instead.

For more info, look at:
kubevirt/kubevirt#11993i

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
